### PR TITLE
Replaced reference to dashCard.js with dashGraph.js

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -90,7 +90,7 @@
 
         <script src="scripts/controllers/GithubStatusController.js"></script>
         <script src="scripts/controllers/BranchStatusController.js"></script>
-        <script src="directive/dashCard.js"></script>
+        <script src="directive/dashGraph.js"></script>
         <!-- endbuild -->
 </body>
 </html>


### PR DESCRIPTION
Either dashGraph.js was intended, or dashCard.js needs to be written.

I'm assuming the former, so I've replaced the reference to dashCard.js with a reference to dashGraph.js.
